### PR TITLE
Create test notebooks for each number type

### DIFF
--- a/python/notebooks/test_megaarray.ipynb
+++ b/python/notebooks/test_megaarray.ipynb
@@ -1,0 +1,117 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing MegaArray Operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bizarromath.meganumber.mega_array import MegaArray"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Addition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaArray.from_decimal_string(\"1,2,3\")\n",
+    "b = MegaArray.from_decimal_string(\"4,5,6\")\n",
+    "c = a.add(b)\n",
+    "print(\"1,2,3 + 4,5,6 =\", c.to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Subtraction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaArray.from_decimal_string(\"10,20,30\")\n",
+    "b = MegaArray.from_decimal_string(\"1,2,3\")\n",
+    "c = a.sub(b)\n",
+    "print(\"10,20,30 - 1,2,3 =\", c.to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multiplication"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaArray.from_decimal_string(\"1,2,3\")\n",
+    "b = MegaArray.from_decimal_string(\"4,5,6\")\n",
+    "product = a.mul(b)\n",
+    "print(\"1,2,3 * 4,5,6 =\", product.to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Division"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaArray.from_decimal_string(\"10,20,30\")\n",
+    "b = MegaArray.from_decimal_string(\"2,2,2\")\n",
+    "quotient = a.div(b)\n",
+    "print(\"10,20,30 / 2,2,2 =\", quotient.to_string())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/python/notebooks/test_megabinary.ipynb
+++ b/python/notebooks/test_megabinary.ipynb
@@ -1,0 +1,117 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing MegaBinary Operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bizarromath.meganumber.mega_binary import MegaBinary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Addition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaBinary(\"1010\")\n",
+    "b = MegaBinary(\"1100\")\n",
+    "c = a.add(b)\n",
+    "print(\"1010 + 1100 =\", c.to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Subtraction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaBinary(\"1100\")\n",
+    "b = MegaBinary(\"1010\")\n",
+    "c = a.sub(b)\n",
+    "print(\"1100 - 1010 =\", c.to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multiplication"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaBinary(\"1010\")\n",
+    "b = MegaBinary(\"1100\")\n",
+    "product = a.mul(b)\n",
+    "print(\"1010 * 1100 =\", product.to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Division"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaBinary(\"1100\")\n",
+    "b = MegaBinary(\"1010\")\n",
+    "quotient = a.div(b)\n",
+    "print(\"1100 / 1010 =\", quotient.to_string())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/python/notebooks/test_megafloat.ipynb
+++ b/python/notebooks/test_megafloat.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing MegaFloat Operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bizarromath.meganumber.mega_float import MegaFloat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Addition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaFloat.from_decimal_string(\"123.456\")\n",
+    "b = MegaFloat.from_decimal_string(\"456.789\")\n",
+    "c = a.add(b)\n",
+    "print(\"123.456 + 456.789 =\", c.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Subtraction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaFloat.from_decimal_string(\"500.123\")\n",
+    "b = MegaFloat.from_decimal_string(\"123.456\")\n",
+    "c = a.sub(b)\n",
+    "print(\"500.123 - 123.456 =\", c.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multiplication"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaFloat.from_decimal_string(\"999.999\")\n",
+    "b = MegaFloat.from_decimal_string(\"1.001\")\n",
+    "product = a.mul(b)\n",
+    "print(\"999.999 * 1.001 =\", product.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Division"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaFloat.from_decimal_string(\"999.999\")\n",
+    "b = MegaFloat.from_decimal_string(\"1.000\")\n",
+    "quotient = a.div(b)\n",
+    "print(\"999.999 / 1.000 =\", quotient.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Power"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base = MegaFloat.from_decimal_string(\"5.5\")\n",
+    "exponent = MegaFloat.from_decimal_string(\"3.0\")\n",
+    "result = base.pow(exponent)\n",
+    "print(\"5.5^3 =\", result.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Square Root"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = MegaFloat.from_decimal_string(\"100.0\")\n",
+    "root = x.sqrt()\n",
+    "print(\"sqrt(100.0) =\", root.to_decimal_string())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/python/notebooks/test_megainteger.ipynb
+++ b/python/notebooks/test_megainteger.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing MegaInteger Operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bizarromath.meganumber.mega_integer import MegaInteger"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Addition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaInteger.from_decimal_string(\"123\")\n",
+    "b = MegaInteger.from_decimal_string(\"456\")\n",
+    "c = a.add(b)\n",
+    "print(\"123 + 456 =\", c.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Subtraction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaInteger.from_decimal_string(\"500\")\n",
+    "b = MegaInteger.from_decimal_string(\"123\")\n",
+    "c = a.sub(b)\n",
+    "print(\"500 - 123 =\", c.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multiplication"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaInteger.from_decimal_string(\"999999\")\n",
+    "b = MegaInteger.from_decimal_string(\"1001\")\n",
+    "product = a.mul(b)\n",
+    "print(\"999999 * 1001 =\", product.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Division"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaInteger.from_decimal_string(\"999999\")\n",
+    "b = MegaInteger.from_decimal_string(\"1000\")\n",
+    "quotient = a.div(b)\n",
+    "print(\"999999 // 1000 =\", quotient.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Power"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base = MegaInteger.from_decimal_string(\"5\")\n",
+    "exponent = MegaInteger.from_decimal_string(\"3\")\n",
+    "result = base.pow(exponent)\n",
+    "print(\"5^3 =\", result.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Square Root"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = MegaInteger.from_decimal_string(\"1000000\")\n",
+    "root = x.sqrt()\n",
+    "print(\"sqrt(1000000) =\", root.to_decimal_string())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/python/notebooks/test_meganumber.ipynb
+++ b/python/notebooks/test_meganumber.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing MegaNumber Operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bizarromath.meganumber.mega_number import MegaNumber"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Addition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaNumber.from_decimal_string(\"123\")\n",
+    "b = MegaNumber.from_decimal_string(\"456\")\n",
+    "c = a.add(b)\n",
+    "print(\"123 + 456 =\", c.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Subtraction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaNumber.from_decimal_string(\"500\")\n",
+    "b = MegaNumber.from_decimal_string(\"123\")\n",
+    "c = a.sub(b)\n",
+    "print(\"500 - 123 =\", c.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multiplication"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaNumber.from_decimal_string(\"999999\")\n",
+    "b = MegaNumber.from_decimal_string(\"1001\")\n",
+    "product = a.mul(b)\n",
+    "print(\"999999 * 1001 =\", product.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Division"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = MegaNumber.from_decimal_string(\"999999\")\n",
+    "b = MegaNumber.from_decimal_string(\"1000\")\n",
+    "quotient = a.div(b)\n",
+    "print(\"999999 // 1000 =\", quotient.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Power"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base = MegaNumber.from_decimal_string(\"5\")\n",
+    "exponent = MegaNumber.from_decimal_string(\"3\")\n",
+    "result = base.pow(exponent)\n",
+    "print(\"5^3 =\", result.to_decimal_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Square Root"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = MegaNumber.from_decimal_string(\"1000000\")\n",
+    "root = x.sqrt()\n",
+    "print(\"sqrt(1000000) =\", root.to_decimal_string())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Add Jupyter notebooks for testing various number types in the `python/notebooks` directory.

* **MegaNumber**: Create `test_meganumber.ipynb` to test addition, subtraction, multiplication, division, power, and square root operations.
* **MegaInteger**: Create `test_megainteger.ipynb` to test addition, subtraction, multiplication, division, power, and square root operations.
* **MegaFloat**: Create `test_megafloat.ipynb` to test addition, subtraction, multiplication, division, power, and square root operations.
* **MegaArray**: Create `test_megaarray.ipynb` to test addition, subtraction, multiplication, and division operations.
* **MegaBinary**: Create `test_megabinary.ipynb` to test addition, subtraction, multiplication, and division operations.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SolaceHarmony/BizarroMath/pull/6?shareId=f4f9102d-c254-474b-8fc2-3ebcf2af7a0b).